### PR TITLE
Added api routes for youthfest and individual event pages

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -7,8 +7,8 @@ import logger from 'morgan';
 import {config} from 'dotenv';
 import cors from 'cors';
 
-import indexRouter from './routes/events.js';
-import usersRouter from './routes/users.js';
+import eventsRouter from './routes/events.js';
+// import usersRouter from './routes/users.js';
 import prisma from './DB/db.config.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -146,10 +146,11 @@ async function fetchEvents() {
     }
   }))
 }
-fetchEvents();
+// createEvent();
+// fetchEvents();
 
-app.use('/api/', indexRouter);
-app.use('/users', usersRouter);
+app.use('/api/', eventsRouter);
+// app.use('/users', usersRouter);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/server/controllers/eventDataControllers.js
+++ b/server/controllers/eventDataControllers.js
@@ -1,0 +1,50 @@
+import prisma from "../DB/db.config.js";
+
+export const specificEventController = async (req, res) => {
+  const eventData = await prisma.event.findUnique({
+    where: {
+      event_id: Number(req.params.eventId),
+    },
+    include: {
+      images: {
+        select: {
+          image_src: true,
+        },
+      },
+      guidelines: {
+        select: {
+          guideline: true,
+        },
+      },
+      tc: {
+        select: {
+          tc: true,
+        },
+      },
+    },
+  });
+  res.json(eventData);
+};
+
+export const youthFestPageController = async (req, res) => {
+  const pageData = await prisma.fest.findUnique({
+    where: {
+      fest_id: 1,
+    },
+    include: {
+      events: {
+        select: {
+          event_id: true,
+          event_name: true,
+          event_desc: true,
+          images: { 
+            select: {
+                image_src: true,
+            } 
+        },
+        },
+      },
+    },
+  });
+  res.json(pageData);
+};

--- a/server/controllers/eventDataControllers.js
+++ b/server/controllers/eventDataControllers.js
@@ -37,6 +37,7 @@ export const youthFestPageController = async (req, res) => {
           event_id: true,
           event_name: true,
           event_desc: true,
+          fest_identifier: true,
           images: { 
             select: {
                 image_src: true,

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -1,10 +1,11 @@
 import express from 'express';
+import { specificEventController, youthFestPageController } from '../controllers/eventDataControllers.js';
 
 const router = express.Router();
 
 /* GET home page. */
-router.get('/', (req, res, next) => {
-  res.json({name: 'YouthFest', status:'success'});
-});
+router.get('/event/:eventId', specificEventController);
+router.get('/youthfest', youthFestPageController);
+
 
 export default router;


### PR DESCRIPTION
Added API routes to do the following:-

- GET data for YouthFest page with Fest details and details for each event i.e. Event name, description, id, identifier, images
- GET data for each event i.e. Event name, description, images, guidelines, T&C, date, venue, etc

fixes #18 